### PR TITLE
Allow ReplyMessageViewModelBuilder to be extended

### DIFF
--- a/ChattoAdditions/Source/Chat Items/ReplyMessages/ReplyMessageViewModelBuilder.swift
+++ b/ChattoAdditions/Source/Chat Items/ReplyMessages/ReplyMessageViewModelBuilder.swift
@@ -1,18 +1,18 @@
 import Foundation
 import Chatto
 
-public final class ReplyMessageViewModelBuilder {
-    private let messageViewModelBuilder = MessageViewModelDefaultBuilder()
+open class ReplyMessageViewModelBuilder {
+    public let messageViewModelBuilder = MessageViewModelDefaultBuilder()
     
-    private let textItemTypes: [ChatItemType]
-    private let photoItemTypes: [ChatItemType]
+    public let textItemTypes: [ChatItemType]
+    public let photoItemTypes: [ChatItemType]
     
     public init(textItemTypes: [ChatItemType], photoItemTypes: [ChatItemType]) {
         self.textItemTypes = textItemTypes
         self.photoItemTypes = photoItemTypes
     }
     
-    public func createViewModel(_ model: MessageModelProtocol?) -> MessageViewModelProtocol? {
+    open func createViewModel(_ model: MessageModelProtocol?) -> MessageViewModelProtocol? {
         guard let model = model else { return nil }
         
         let viewModel = messageViewModelBuilder.createMessageViewModel(model)

--- a/ChattoApp/ChattoApp.xcodeproj/project.pbxproj
+++ b/ChattoApp/ChattoApp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		55A77B4A1FCC5EE70040C77E /* MessagesSelectorProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A77B491FCC5EE70040C77E /* MessagesSelectorProtocol.swift */; };
 		55A77B4C1FCC5FFB0040C77E /* BaseMessagesSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55A77B4B1FCC5FFB0040C77E /* BaseMessagesSelector.swift */; };
 		55EE230821BFFD6600D50A1C /* ScrollToBottomButtonChatViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55EE230721BFFD6600D50A1C /* ScrollToBottomButtonChatViewController.swift */; };
+		AFCE46032C41A58900B0F40E /* DemoReplyMessageViewModelBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFCE46022C41A58900B0F40E /* DemoReplyMessageViewModelBuilder.swift */; };
 		C33FBFB01BDE441C008E3545 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C33FBFAF1BDE441C008E3545 /* Assets.xcassets */; };
 		C33FBFB31BDE441C008E3545 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = C33FBFB11BDE441C008E3545 /* LaunchScreen.storyboard */; };
 		C341D42E1C9635DF00FD3463 /* TimeSeparatorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C341D42B1C9635DF00FD3463 /* TimeSeparatorModel.swift */; };
@@ -99,6 +100,7 @@
 		55EE230721BFFD6600D50A1C /* ScrollToBottomButtonChatViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollToBottomButtonChatViewController.swift; sourceTree = "<group>"; };
 		623390018DA74FF277EE2626 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DABD92E2BA40464C1727DA2 /* Pods-ChattoApp.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ChattoApp.release.xcconfig"; path = "Pods/Target Support Files/Pods-ChattoApp/Pods-ChattoApp.release.xcconfig"; sourceTree = "<group>"; };
+		AFCE46022C41A58900B0F40E /* DemoReplyMessageViewModelBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DemoReplyMessageViewModelBuilder.swift; sourceTree = "<group>"; };
 		C33FBFA51BDE441C008E3545 /* ChattoApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChattoApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C33FBFAF1BDE441C008E3545 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		C33FBFB21BDE441C008E3545 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -178,6 +180,7 @@
 		55A77B471FCC41CC0040C77E /* Chat Items */ = {
 			isa = PBXGroup;
 			children = (
+				AFCE46012C41A55900B0F40E /* Reply */,
 				268CD56B21FA3C3900DEE2C2 /* Compound Messages */,
 				DECD501821AEEABF00988729 /* Content Aware Input  */,
 				55A77B481FCC42250040C77E /* Base Message */,
@@ -215,6 +218,14 @@
 				26FAADC323747B1300F62D01 /* AsyncAvatarLoadingViewController.swift */,
 			);
 			path = "Chat View Controllers";
+			sourceTree = "<group>";
+		};
+		AFCE46012C41A55900B0F40E /* Reply */ = {
+			isa = PBXGroup;
+			children = (
+				AFCE46022C41A58900B0F40E /* DemoReplyMessageViewModelBuilder.swift */,
+			);
+			path = Reply;
 			sourceTree = "<group>";
 		};
 		B616EDF620454A787C7E7D84 /* Pods */ = {
@@ -519,6 +530,7 @@
 				55EE230821BFFD6600D50A1C /* ScrollToBottomButtonChatViewController.swift in Sources */,
 				5587302E1FCD7EE5005BC2EC /* MessagesSelectionChatViewController.swift in Sources */,
 				26FAADC423747B1300F62D01 /* AsyncAvatarLoadingViewController.swift in Sources */,
+				AFCE46032C41A58900B0F40E /* DemoReplyMessageViewModelBuilder.swift in Sources */,
 				268CD578220336EB00DEE2C2 /* DemoTextMessageContentFactory.swift in Sources */,
 				C3F91DCC1C75EFE300D461D2 /* SendingStatusCollectionViewCell.swift in Sources */,
 				26D63B4C250F3154007BC13C /* DemoReplyActionHandler.swift in Sources */,

--- a/ChattoApp/ChattoApp/Source/Chat Items/Reply/DemoReplyMessageViewModelBuilder.swift
+++ b/ChattoApp/ChattoApp/Source/Chat Items/Reply/DemoReplyMessageViewModelBuilder.swift
@@ -1,0 +1,27 @@
+import Foundation
+import ChattoAdditions
+
+final class DemoReplyMessageViewModelBuilder: ReplyMessageViewModelBuilder {
+    override func createViewModel(_ model: MessageModelProtocol?) -> MessageViewModelProtocol? {
+        guard let model = model else { return nil }
+        
+        let viewModel = messageViewModelBuilder.createMessageViewModel(model)
+
+        return switch model.type {
+        case _ where textItemTypes.contains(model.type):
+            DemoTextMessageViewModel(
+                textMessage: model as! DemoTextMessageModel,
+                messageViewModel: viewModel,
+                replyMessageViewModel: nil
+            )
+        case _ where photoItemTypes.contains(model.type):
+            DemoPhotoMessageViewModel(
+                photoMessage: model as! DemoPhotoMessageModel,
+                messageViewModel: viewModel,
+                replyMessageViewModel: nil
+            )
+        default:
+            nil
+        }
+    }
+}

--- a/ChattoApp/ChattoApp/Source/Chat Items/Text Messages/DemoTextMessageViewModel.swift
+++ b/ChattoApp/ChattoApp/Source/Chat Items/Text Messages/DemoTextMessageViewModel.swift
@@ -48,7 +48,7 @@ public class DemoTextMessageViewModelBuilder: ViewModelBuilderProtocol {
 
     public func createViewModel(_ textMessage: DemoTextMessageModel, reply: MessageModelProtocol?) -> DemoTextMessageViewModel {
         let messageViewModel = self.messageViewModelBuilder.createMessageViewModel(textMessage)
-        var replyMessageViewModel = replyMessageViewModelBuilder.createViewModel(reply)
+        let replyMessageViewModel = replyMessageViewModelBuilder.createViewModel(reply)
         
         let textMessageViewModel = DemoTextMessageViewModel(
             textMessage: textMessage,

--- a/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
+++ b/ChattoApp/ChattoApp/Source/Chat View Controllers/DemoChatViewController.swift
@@ -74,7 +74,7 @@ class DemoChatViewController: BaseChatViewController {
 
     override func createPresenterBuilders() -> [ChatItemType: [ChatItemPresenterBuilderProtocol]] {
 
-        let replyMessageViewModelBuilder = ReplyMessageViewModelBuilder(
+        let replyMessageViewModelBuilder = DemoReplyMessageViewModelBuilder(
             textItemTypes: [DemoTextMessageModel.chatItemType],
             photoItemTypes: [DemoPhotoMessageModel.chatItemType]
         )


### PR DESCRIPTION
We need this in order to allow customization in our side (Husband) so we can show restricted view for example.

Allowing this class to be extended will allow us to return our own types (PSSTextMessageViewModel, PSSPhotoMessageViewModel) so we avoid type erasure.